### PR TITLE
Add simple response cache for fuzzy search

### DIFF
--- a/loki/base_app/decorators.py
+++ b/loki/base_app/decorators.py
@@ -1,0 +1,25 @@
+from rest_framework.response import Response
+from django.core.cache import cache
+from functools import wraps
+
+from .helper import split_and_lower
+
+
+def cache_response(view_func):
+    @wraps(view_func)
+    def wrapper(request, *args, **kwargs):
+        cache_key = " ".join(split_and_lower(request.data['query']))
+        data = cache.get(cache_key)
+
+        if data is not None:
+            print('Query {} found in cache'.format(cache_key))
+            print(data)
+            return Response(data)
+
+        result = view_func(request, *args, **kwargs)
+        cache.set(cache_key, result.data)
+        print('Cache miss, setting')
+
+        return result
+
+    return wrapper

--- a/loki/base_app/helper.py
+++ b/loki/base_app/helper.py
@@ -58,3 +58,7 @@ def validate_password(value):
     # check for letter
     if not any(char.isalpha() for char in value):
         raise ValidationError(_('Password must container at least 1 letter.'))
+
+
+def split_and_lower(query):
+    return [w.lower() for w in query.split()]

--- a/loki/base_app/views.py
+++ b/loki/base_app/views.py
@@ -13,6 +13,8 @@ from .helper import crop_image, validate_password
 from .models import BaseUserRegisterToken, BaseUserPasswordResetToken
 from .services import fuzzy_search_education_place
 
+from .decorators import cache_response
+
 
 @api_view(['GET'])
 @permission_classes((IsAuthenticated,))
@@ -59,6 +61,7 @@ def base_user_update(request):
 
 
 @api_view(['POST'])
+@cache_response
 def education_place_suggest(request):
     query = request.data.get('query', '')
     words = [w.lower() for w in query.split()]

--- a/loki/loki/example_local_settings.py
+++ b/loki/loki/example_local_settings.py
@@ -75,3 +75,14 @@ CELERYBEAT_SCHEDULE = {
         'schedule': timedelta(minutes=1),
     },
 }
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'loki_cache',
+        'TIMEOUT': 60 * 60,
+        'OPTIONS': {
+            'MAX_ENTRIES': 1000,
+        }
+    }
+}


### PR DESCRIPTION
- There's a change to settings file - see `example_local_settings.py`
- `$ python manage.py createcachetable` needs to be run for the cache to work